### PR TITLE
feat(rds): add check for audit logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ The available log levels are: `debug`, `info`, `warn`, `error`, `fatal`, `panic`
 - AWS_RDS_010 Aurora RDS are encrypted
 - AWS_RDS_011 Aurora RDS logs are exported to cloudwatch
 - AWS_RDS_012 Aurora RDS aren't publicly accessible
+- AWS_RDS_013 RDS / Aurora RDS should have audit logs enabled
 
 ### S3 Bucket
 - AWS_S3_001 S3 are encrypted

--- a/aws/rds/getter.go
+++ b/aws/rds/getter.go
@@ -2,6 +2,9 @@ package rds
 
 import (
 	"context"
+	"slices"
+	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
@@ -11,6 +14,8 @@ import (
 type RDSGetObjectAPI interface {
 	DescribeDBInstances(ctx context.Context, input *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error)
 	DescribeDBClusters(ctx context.Context, input *rds.DescribeDBClustersInput, optFns ...func(*rds.Options)) (*rds.DescribeDBClustersOutput, error)
+	DescribeDBLogFiles(ctx context.Context, input *rds.DescribeDBLogFilesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBLogFilesOutput, error)
+	DownloadDBLogFilePortion(ctx context.Context, input *rds.DownloadDBLogFilePortionInput, optFns ...func(*rds.Options)) (*rds.DownloadDBLogFilePortionOutput, error)
 }
 
 func GetListRDS(svc RDSGetObjectAPI) []types.DBInstance {
@@ -69,4 +74,134 @@ func GetListDBClusters(svc RDSGetObjectAPI) []types.DBCluster {
 	}
 
 	return clusters
+}
+
+func GetListDBLogFiles(svc RDSGetObjectAPI, dbInstanceIdentifier string) []types.DescribeDBLogFilesDetails {
+	params := &rds.DescribeDBLogFilesInput{
+		DBInstanceIdentifier: &dbInstanceIdentifier,
+	}
+	var logFiles []types.DescribeDBLogFilesDetails
+	resp, err := svc.DescribeDBLogFiles(context.TODO(), params)
+	if err != nil {
+		logger.Logger.Error(err.Error())
+		// Return an empty list of instances
+		return []types.DescribeDBLogFilesDetails{}
+	}
+	logFiles = append(logFiles, resp.DescribeDBLogFiles...)
+	for {
+		if resp.Marker != nil {
+			params.Marker = resp.Marker
+			resp, err = svc.DescribeDBLogFiles(context.TODO(), params)
+			logFiles = append(logFiles, resp.DescribeDBLogFiles...)
+			if err != nil {
+				logger.Logger.Error(err.Error())
+				// Return an empty list of instances
+				return []types.DescribeDBLogFilesDetails{}
+			}
+		} else {
+			break
+		}
+	}
+
+	return logFiles
+}
+
+type InstanceToLogFiles struct {
+	Instance              types.DBInstance
+	LogFiles              []types.DescribeDBLogFilesDetails
+	RecentLogFilesPortion string
+}
+
+func GetInstancesToLogFiles(svc RDSGetObjectAPI, instances []types.DBInstance) []InstanceToLogFiles {
+	var wg sync.WaitGroup
+	rdsToLogFilesChan := make(chan InstanceToLogFiles, len(instances))
+	var rdsToLogFiles []InstanceToLogFiles
+
+	// Rate limit to 5 concurrent requests
+	sem := make(chan struct{}, 5)
+
+	for _, instance := range instances {
+		wg.Add(1)
+		go func(instance types.DBInstance) {
+			defer wg.Done()
+
+			// Acquire semaphore
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			instanceToLogFile := InstanceToLogFiles{Instance: instance}
+			logFiles := GetListDBLogFiles(svc, *instance.DBInstanceIdentifier)
+			instanceToLogFile.LogFiles = logFiles
+
+			if *instance.Engine == "postgres" || *instance.Engine == "aurora-postgresql" {
+				slices.SortFunc(logFiles, func(a, b types.DescribeDBLogFilesDetails) int {
+					return int(*a.LastWritten) - int(*b.LastWritten)
+				})
+				logFileCount := len(logFiles)
+				if logFileCount > 3 {
+					logFileCount = 3
+				}
+
+				var portionWg sync.WaitGroup
+				portions := make(chan string, logFileCount)
+
+				// Inner semaphore for log file portions, limit to 3 concurrent
+				portionSem := make(chan struct{}, 3)
+
+				for i := 0; i < logFileCount; i++ {
+					portionWg.Add(1)
+					go func(i int) {
+						defer portionWg.Done()
+
+						// Acquire portion semaphore
+						portionSem <- struct{}{}
+						defer func() { <-portionSem }()
+
+						// Add small delay between requests
+						time.Sleep(100 * time.Millisecond)
+
+						portion := GetLogFilePortion(svc, *instance.DBInstanceIdentifier, *logFiles[i].LogFileName, "")
+						portions <- portion
+					}(i)
+				}
+
+				go func() {
+					portionWg.Wait()
+					close(portions)
+				}()
+
+				for portion := range portions {
+					instanceToLogFile.RecentLogFilesPortion += portion
+				}
+			}
+			rdsToLogFilesChan <- instanceToLogFile
+		}(instance)
+	}
+
+	go func() {
+		wg.Wait()
+		close(rdsToLogFilesChan)
+	}()
+
+	for result := range rdsToLogFilesChan {
+		rdsToLogFiles = append(rdsToLogFiles, result)
+	}
+
+	return rdsToLogFiles
+}
+
+func GetLogFilePortion(svc RDSGetObjectAPI, dbInstanceIdentifier string, logFileName string, marker string) string {
+	params := &rds.DownloadDBLogFilePortionInput{
+		DBInstanceIdentifier: &dbInstanceIdentifier,
+		LogFileName:          &logFileName,
+	}
+	if marker != "" {
+		params.Marker = &marker
+	}
+	resp, err := svc.DownloadDBLogFilePortion(context.TODO(), params)
+	if err != nil {
+		logger.Logger.Error(err.Error())
+	}
+
+	return *resp.LogFileData
 }

--- a/aws/rds/getter_test.go
+++ b/aws/rds/getter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 )
@@ -23,7 +24,20 @@ func (m mockGetRdsAPI) DescribeDBClusters(ctx context.Context, input *rds.Descri
 	return &rds.DescribeDBClustersOutput{
 		DBClusters: []types.DBCluster{},
 	}, nil
+}
 
+func (m mockGetRdsAPI) DescribeDBLogFiles(ctx context.Context, input *rds.DescribeDBLogFilesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBLogFilesOutput, error) {
+	// Return an empty list of RDS log files
+	return &rds.DescribeDBLogFilesOutput{
+		DescribeDBLogFiles: []types.DescribeDBLogFilesDetails{},
+	}, nil
+}
+
+func (m mockGetRdsAPI) DownloadDBLogFilePortion(ctx context.Context, input *rds.DownloadDBLogFilePortionInput, optFns ...func(*rds.Options)) (*rds.DownloadDBLogFilePortionOutput, error) {
+	// Return an empty list of RDS log files
+	return &rds.DownloadDBLogFilePortionOutput{
+		LogFileData: aws.String("AUDIT: "),
+	}, nil
 }
 
 func TestGetListRDS(t *testing.T) {

--- a/aws/rds/rdsAuditLogs.go
+++ b/aws/rds/rdsAuditLogs.go
@@ -1,0 +1,47 @@
+package rds
+
+import (
+	"strings"
+
+	"github.com/padok-team/yatas/plugins/commons"
+)
+
+func checkIfAuditLogsEnabled(checkConfig commons.CheckConfig, dbInstances []InstanceToLogFiles, testName string) {
+	var check commons.Check
+	check.InitCheck("RDS / Aurora RDS audit logs should be enabled", "Check if RDS / Aurora RDS audit logs are enabled (supports MySQL, Aurora MySQL, MariaDB, PostgreSQL, Aurora PostgreSQL)", testName, []string{"Security", "Good Practice"})
+	// MySQL/MariaDB case: check if log files beginning with audit are present
+	for _, dbInstance := range dbInstances {
+		if *dbInstance.Instance.Engine == "mysql" || *dbInstance.Instance.Engine == "aurora-mysql" || *dbInstance.Instance.Engine == "mariadb" {
+			auditLogFiles := []string{}
+			for _, logFile := range dbInstance.LogFiles {
+				if strings.HasPrefix(*logFile.LogFileName, "audit") {
+					auditLogFiles = append(auditLogFiles, *logFile.LogFileName)
+				}
+			}
+			if len(auditLogFiles) == 0 {
+				message := "No audit log files found for instance " + *dbInstance.Instance.DBInstanceIdentifier
+				result := commons.Result{Status: "FAIL", Message: message, ResourceID: *dbInstance.Instance.DBInstanceArn}
+				check.AddResult(result)
+			} else {
+				message := "Audit log files found for instance " + *dbInstance.Instance.DBInstanceIdentifier
+				result := commons.Result{Status: "OK", Message: message, ResourceID: *dbInstance.Instance.DBInstanceArn}
+				check.AddResult(result)
+			}
+		}
+
+		// PostgreSQL case: check if there is a line with "AUDIT: " in the recent log files portion
+		if *dbInstance.Instance.Engine == "postgres" || *dbInstance.Instance.Engine == "aurora-postgresql" {
+			if strings.Contains(dbInstance.RecentLogFilesPortion, "AUDIT: ") {
+				message := "Audit log files found for instance " + *dbInstance.Instance.DBInstanceIdentifier
+				result := commons.Result{Status: "OK", Message: message, ResourceID: *dbInstance.Instance.DBInstanceArn}
+				check.AddResult(result)
+			} else {
+				message := "No audit log files found for instance " + *dbInstance.Instance.DBInstanceIdentifier
+				result := commons.Result{Status: "FAIL", Message: message, ResourceID: *dbInstance.Instance.DBInstanceArn}
+				check.AddResult(result)
+			}
+		}
+	}
+
+	checkConfig.Queue <- check
+}

--- a/aws/rds/rdsAuditLogs_test.go
+++ b/aws/rds/rdsAuditLogs_test.go
@@ -1,0 +1,251 @@
+package rds
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds/types"
+	"github.com/padok-team/yatas/plugins/commons"
+)
+
+func TestCheckIfAuditLogsEnabledSuccess(t *testing.T) {
+	type args struct {
+		checkConfig commons.CheckConfig
+		dbInstances []InstanceToLogFiles
+		testName    string
+	}
+
+	// Mock log file portion to avoid nil pointer in getter
+	logPortion := "test log portion"
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "Test MySQL RDS with audit logs",
+			args: args{
+				checkConfig: commons.CheckConfig{
+					Queue: make(chan commons.Check, 1),
+					Wg:    &sync.WaitGroup{},
+				},
+				dbInstances: []InstanceToLogFiles{
+					{
+						Instance: types.DBInstance{
+							DBInstanceIdentifier: aws.String("mysql-db"),
+							DBInstanceArn:        aws.String("arn:aws:rds:us-west-2:123456789012:db:mysql-db"),
+							Engine:               aws.String("mysql"),
+						},
+						LogFiles: []types.DescribeDBLogFilesDetails{
+							{
+								LogFileName: aws.String("audit.log"),
+								LastWritten: aws.Int64(1640995200000), // 2022-01-01
+							},
+						},
+						RecentLogFilesPortion: logPortion,
+					},
+				},
+				testName: "AWS_RDS_001",
+			},
+		},
+		{
+			name: "Test Aurora MySQL with audit logs",
+			args: args{
+				checkConfig: commons.CheckConfig{
+					Queue: make(chan commons.Check, 1),
+					Wg:    &sync.WaitGroup{},
+				},
+				dbInstances: []InstanceToLogFiles{
+					{
+						Instance: types.DBInstance{
+							DBInstanceIdentifier: aws.String("aurora-mysql-db"),
+							DBInstanceArn:        aws.String("arn:aws:rds:us-west-2:123456789012:db:aurora-mysql-db"),
+							Engine:               aws.String("aurora-mysql"),
+						},
+						LogFiles: []types.DescribeDBLogFilesDetails{
+							{
+								LogFileName: aws.String("audit/audit.log"),
+								LastWritten: aws.Int64(1640995200000), // 2022-01-01
+							},
+						},
+						RecentLogFilesPortion: logPortion,
+					},
+				},
+				testName: "AWS_RDS_001",
+			},
+		},
+		{
+			name: "Test PostgreSQL RDS with audit logs",
+			args: args{
+				checkConfig: commons.CheckConfig{
+					Queue: make(chan commons.Check, 1),
+					Wg:    &sync.WaitGroup{},
+				},
+				dbInstances: []InstanceToLogFiles{
+					{
+						Instance: types.DBInstance{
+							DBInstanceIdentifier: aws.String("postgres-db"),
+							DBInstanceArn:        aws.String("arn:aws:rds:us-west-2:123456789012:db:postgres-db"),
+							Engine:               aws.String("postgres"),
+						},
+						RecentLogFilesPortion: "AUDIT: SESSION,1,1,WRITE,2024-01-01 00:00:00 UTC",
+					},
+				},
+				testName: "AWS_RDS_001",
+			},
+		},
+		{
+			name: "Test Aurora PostgreSQL with audit logs",
+			args: args{
+				checkConfig: commons.CheckConfig{
+					Queue: make(chan commons.Check, 1),
+					Wg:    &sync.WaitGroup{},
+				},
+				dbInstances: []InstanceToLogFiles{
+					{
+						Instance: types.DBInstance{
+							DBInstanceIdentifier: aws.String("aurora-postgres-db"),
+							DBInstanceArn:        aws.String("arn:aws:rds:us-west-2:123456789012:db:aurora-postgres-db"),
+							Engine:               aws.String("aurora-postgresql"),
+						},
+						RecentLogFilesPortion: "AUDIT: SESSION,1,1,DDL,2024-01-01 00:00:00 UTC",
+					},
+				},
+				testName: "AWS_RDS_001",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkIfAuditLogsEnabled(tt.args.checkConfig, tt.args.dbInstances, tt.args.testName)
+			tt.args.checkConfig.Wg.Add(1)
+			go func() {
+				for check := range tt.args.checkConfig.Queue {
+					if check.Status != "OK" {
+						t.Errorf("checkIfAuditLogsEnabled() = %v", check)
+					}
+					tt.args.checkConfig.Wg.Done()
+				}
+			}()
+			tt.args.checkConfig.Wg.Wait()
+		})
+	}
+}
+
+func TestCheckIfAuditLogsEnabledFail(t *testing.T) {
+	type args struct {
+		checkConfig commons.CheckConfig
+		dbInstances []InstanceToLogFiles
+		testName    string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "Test MySQL RDS without audit logs",
+			args: args{
+				checkConfig: commons.CheckConfig{
+					Queue: make(chan commons.Check, 1),
+					Wg:    &sync.WaitGroup{},
+				},
+				dbInstances: []InstanceToLogFiles{
+					{
+						Instance: types.DBInstance{
+							DBInstanceIdentifier: aws.String("mysql-db"),
+							DBInstanceArn:        aws.String("arn:aws:rds:us-west-2:123456789012:db:mysql-db"),
+							Engine:               aws.String("mysql"),
+						},
+						LogFiles: []types.DescribeDBLogFilesDetails{
+							{
+								LogFileName: aws.String("error.log"),
+							},
+						},
+					},
+				},
+				testName: "AWS_RDS_001",
+			},
+		},
+		{
+			name: "Test Aurora MySQL without audit logs",
+			args: args{
+				checkConfig: commons.CheckConfig{
+					Queue: make(chan commons.Check, 1),
+					Wg:    &sync.WaitGroup{},
+				},
+				dbInstances: []InstanceToLogFiles{
+					{
+						Instance: types.DBInstance{
+							DBInstanceIdentifier: aws.String("aurora-mysql-db"),
+							DBInstanceArn:        aws.String("arn:aws:rds:us-west-2:123456789012:db:aurora-mysql-db"),
+							Engine:               aws.String("aurora-mysql"),
+						},
+						LogFiles: []types.DescribeDBLogFilesDetails{
+							{
+								LogFileName: aws.String("slowquery.log"),
+							},
+						},
+					},
+				},
+				testName: "AWS_RDS_001",
+			},
+		},
+		{
+			name: "Test PostgreSQL RDS without audit logs",
+			args: args{
+				checkConfig: commons.CheckConfig{
+					Queue: make(chan commons.Check, 1),
+					Wg:    &sync.WaitGroup{},
+				},
+				dbInstances: []InstanceToLogFiles{
+					{
+						Instance: types.DBInstance{
+							DBInstanceIdentifier: aws.String("postgres-db"),
+							DBInstanceArn:        aws.String("arn:aws:rds:us-west-2:123456789012:db:postgres-db"),
+							Engine:               aws.String("postgres"),
+						},
+						RecentLogFilesPortion: "LOG: database system is ready to accept connections",
+					},
+				},
+				testName: "AWS_RDS_001",
+			},
+		},
+		{
+			name: "Test Aurora PostgreSQL without audit logs",
+			args: args{
+				checkConfig: commons.CheckConfig{
+					Queue: make(chan commons.Check, 1),
+					Wg:    &sync.WaitGroup{},
+				},
+				dbInstances: []InstanceToLogFiles{
+					{
+						Instance: types.DBInstance{
+							DBInstanceIdentifier: aws.String("aurora-postgres-db"),
+							DBInstanceArn:        aws.String("arn:aws:rds:us-west-2:123456789012:db:aurora-postgres-db"),
+							Engine:               aws.String("aurora-postgresql"),
+						},
+						RecentLogFilesPortion: "LOG: checkpoint starting: time",
+					},
+				},
+				testName: "AWS_RDS_001",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checkIfAuditLogsEnabled(tt.args.checkConfig, tt.args.dbInstances, tt.args.testName)
+			tt.args.checkConfig.Wg.Add(1)
+			go func() {
+				for check := range tt.args.checkConfig.Queue {
+					if check.Status != "FAIL" {
+						t.Errorf("checkIfAuditLogsEnabled() = %v", check)
+					}
+					tt.args.checkConfig.Wg.Done()
+				}
+			}()
+			tt.args.checkConfig.Wg.Wait()
+		})
+	}
+}


### PR DESCRIPTION
This new check verifies :

- For MySQL / Aurora MySQL / MariaDB engines : log files with audit/ prefix are present (https://aws.amazon.com/blogs/database/configuring-an-audit-log-to-capture-database-activities-for-amazon-rds-for-mysql-and-amazon-aurora-with-mysql-compatibility/)
- For PostgreSQL / Aurora PostgreSQL engines : the "AUDIT:" sequence is present in the 3 most recent log files (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.PostgreSQL.CommonDBATasks.pgaudit.auditing.html)

This check does not support any other engine not mentioned here (oracle, sql server...)